### PR TITLE
doc: remove the checkout step in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,6 @@ jobs:
   check-for-cc:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
       - name: check-for-cc
         id: check-for-cc
         uses: agenthunt/conventional-commit-checker-action@v1.0.0


### PR DESCRIPTION
This is not needed as the action only checks the Pull Request metadata and nothing else.
Checkouting the repository is just slowing down the execution.