### PR TITLE
doc: Update README.md example to use newer tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: check-for-cc
         id: check-for-cc
-        uses: agenthunt/conventional-commit-checker-action@v1.0.0
+        uses: agenthunt/conventional-commit-checker-action@v2.0.0
 ```
 
 ## NOTE


### PR DESCRIPTION
The v1.0.0 tag is not the latest. 

Update to v2.0.0 to use the currently-latest tag.